### PR TITLE
Set button background color to avoid browser inconsistency.

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -276,6 +276,7 @@ button a {
     letter-spacing:0;
     padding-left: 40px;
     padding-right: 40px;
+    background-color: white;
 }
 
 section#openLibertyAndMp {


### PR DESCRIPTION
Fixes #7 

Tested on Chrome, Firefox. 
The styling change never appeared in Safari on reload, but worked when applied manually via debugger.