### PR TITLE
🍎 Mac dependencies.

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+cask "java"
+brew "maven"


### PR DESCRIPTION
As a Mac developer I'd like to see project dependencies at a glance and a way to install them. 


[Home Brew at brew.sh](https://brew.sh) is the de-facto package manager for macOs that is used in the open-source community. 

PR:
A `Brewfile` in the root of a project allows a software engineer to issue one command to install project dependencies on a Mac. These can be ports of linux packages, freeware applications, or even apps from the App Store. This `Brewfile` adds the two tools needed to run this on a Mac:
- java
- maven