### PR TITLE
Use proper property name.

### DIFF
--- a/src/main/webapp/js/mpData.js
+++ b/src/main/webapp/js/mpData.js
@@ -148,9 +148,9 @@ function getHealth() {
 
             resp.checks.forEach(function (service) {
                 serviceName.innerText = service.name;
-                healthStatus.innerText = service.state;
+                healthStatus.innerText = service.status;
 
-                if (service.state === "UP") {
+                if (service.status === "UP") {
                     healthBox.style.backgroundColor = "#f0f7e1";
                     healthIcon.setAttribute("src", "img/systemUp.svg");
                 } else {


### PR DESCRIPTION
The correct property name is `status`, not `state` according to the official docs https://github.com/eclipse/microprofile-health#on-the-wire
```
{

    "checks": [
        {
            "data": {
                "memory used": 42161664,
                "memory max": 536870912
            },
            "name": "SystemResource liveness check",
            "status": "UP"
        },
        {
            "data": {
                "services": "available"
            },
            "name": "SystemResource readiness check",
            "status": "UP"
        }
    ],
    "status": "UP"

}
```
as result in the `inventory` ui it looks like system endpoint is down, even if it is "UP"

![System-is-down](https://user-images.githubusercontent.com/229410/66565981-b43da180-eb5b-11e9-87a8-a2ddf1ab55bc.png)
