### PR TITLE
Remove embedded keystore from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN features.sh
 
 COPY --chown=1001:0 target/*.war /config/apps/
 
-RUN configure.sh
+RUN configure.sh && rm -rf /output/resources/security/

--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -16,7 +16,6 @@
   <variable name="app.context.root" defaultValue="/"/>
 
   <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
-  <keyStore id="defaultKeyStore" password="OpenLiberty" />
 
   <webApplication location="io.openliberty.sample.getting.started.war" contextRoot="${app.context.root}"/>
 </server>


### PR DESCRIPTION
This PR will remove keystore  from the final docker image so that each user will have their own certificate once running.

Also allows user to bring their own PEM certs (keystore is generated by the image entrypoint script)

Eg:

docker run --rm -it --name getting-started -p 9080:9080 -p 9443:9443 -v $(pwd)/certs:/etc/x509/certs  getting-started-app
