### PR TITLE
Upgrade dep versions, integrate tests, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The sample application provides a simple example of how to get started with Open
   - `liberty/config/server.xml` - The server configuration for the liberty runtime
   - `META-INF` - Contains the metadata files for MicroProfile Config including how to load CustomConfigSource.java
   - `webapp` - Contains the Web UI for the application.
+  - `test/java/it/io/openliberty/sample/health`
+    - `HealthIT.java` - Test cases for a sample application running on `localhost`
+    - `HealthUtilIT.java` - Utility methods for functional tests
 - `resources/CustomConfigSource.json` - Contains the data that is read by the MicroProfile Config ConfigSource.
 - `Dockerfile` - The Dockerfile for building the sample
 - `pom.xml` - The Maven POM file
@@ -64,3 +67,22 @@ podman run -p 9080:9080 icr.io/appcafe/open-liberty/samples/getting-started
 Open a browser to http://localhost:9080
 
 ![image](https://user-images.githubusercontent.com/3076261/117993383-4f34c980-b305-11eb-94b5-fa7319bc2850.png)
+
+## Run the functional tests
+
+The test cases uses [JUnit 5](https://junit.org/junit5/) and 
+[Maven Failsafe Plugin](https://maven.apache.org/surefire/maven-failsafe-plugin/index.html) defined 
+in [`pom.xml`](pom.xml).
+
+> Note: Sample appplication must be running on `http://localhost` before running the test cases. 
+> <br>
+> See [`HealthUtilIT.java`](src/test/java/it/io/openliberty/sample/health/HealthUtilIT.java) to change 
+> the change the sample application target URL.
+
+To run the test cases against a running sample application, use the following command
+```
+mvnw failsafe:integration-test
+```
+
+To view the test results, look at the console output or look under 
+directory  `target/failsafe-reports`

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Plugin versions -->
-    <version.liberty-maven-plugin>3.5.1</version.liberty-maven-plugin>
+    <version.liberty-maven-plugin>3.6.1</version.liberty-maven-plugin>
     <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
     <!-- Liberty configuration -->
@@ -44,13 +44,13 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
-      <version>3.4.3</version>
+      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-extension-providers</artifactId>
-      <version>3.4.3</version>
+      <version>3.5.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -91,6 +91,9 @@
             <https.port>${liberty.var.default.https.port}</https.port>
             <app.context.root>${liberty.var.app.context.root}</app.context.root>
           </systemPropertyVariables>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- Upgrade to Liberty Maven Plugin 3.6.1

- Upgrade `cxf-rt-rs-client` and `cxf-rt-rs-extension-providers`
to 3.5.3

- Add existing tests and use command `mvnw failsafe:integration-test`
to run the tests against a running sample application instance

- Add information about the tests to README.md