### PR TITLE
Upgrade features

### DIFF
--- a/src/main/liberty/config/server.xml
+++ b/src/main/liberty/config/server.xml
@@ -3,9 +3,9 @@
   <featureManager>
     <feature>restfulWS-3.1</feature>
     <feature>jsonb-3.0</feature>
-    <feature>mpMetrics-5.0</feature>
+    <feature>mpMetrics-5.1</feature>
     <feature>mpHealth-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
   <applicationManager autoExpand="true" />


### PR DESCRIPTION
Update features to MicroProfile 6.1 so that the sample can be compatible with mpTelemetry-2.0

Fixes https://github.com/OpenLiberty/sample-getting-started/issues/113