### PR TITLE
Install required packages for linperf.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ LABEL \
   summary="Sample app running on Open Liberty that uses Eclipse MicroProfile" \
   description="This image contains a sample application that displays the Java system properties and demonstrates MicroProfile Config, Health and Metrics."
 
+USER 0
+RUN command -v yum && pkgcmd=yum || pkgcmd=microdnf && $pkgcmd update -y && $pkgcmd install -y procps-ng net-tools ncurses hostname
+USER 1001
+
 COPY --chown=1001:0 src/main/liberty/config/ /config/
 
 RUN features.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ LABEL \
   summary="Sample app running on Open Liberty that uses Eclipse MicroProfile" \
   description="This image contains a sample application that displays the Java system properties and demonstrates MicroProfile Config, Health and Metrics."
 
+# Install required packages to run linperf.sh
 USER 0
-RUN command -v yum && pkgcmd=yum || pkgcmd=microdnf && $pkgcmd update -y && $pkgcmd install -y procps-ng net-tools ncurses hostname
+RUN command -v yum && pkgcmd=yum || pkgcmd=microdnf && ($pkgcmd update -y && $pkgcmd install -y procps-ng net-tools ncurses hostname)
 USER 1001
 
 COPY --chown=1001:0 src/main/liberty/config/ /config/


### PR DESCRIPTION
This temporarily uses root privilege to install required packages to run the Liberty MustGather (linperf.sh).
It supports Liberty Java images using version 21 (microdnf) and lower (yum).