### PR TITLE
Delete .whitesource

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,0 @@
-{
-"settingsInheritedFrom": "whitesource-config/whitesource-config@master"
-}


### PR DESCRIPTION
The https://github.com/OpenLiberty/sample-getting-started repo is just a sample application that isn't shipped to customers. Removing the whitesource file to prevent this project from being picked up by SAST scans.